### PR TITLE
GEARRT unit check: luminosity tests

### DIFF
--- a/GEARRTUnitCheck/README
+++ b/GEARRTUnitCheck/README
@@ -28,16 +28,22 @@ Instructions
 
     The program expects the file to be named "simulation_parameters.yml" by
     default. If you want to change that, you can find the filename definition 
-    at the top of the `main()` function in `main.c`
+    at the top of the `main()` function in `main.c`. In particular, change
+    this line: 
+    ```
+      char *IC_params_filename = "simulation_parameters.yml";
+    ```
 
 2)  Provide `main.c` with the correct SWIFT runtime parameter file
     Locate the definition of 
-        `char *swift_param_filename = "swift_parameters.yml";`
+    ```
+      char *sim_run_params_filename = "swift_parameters.yml";`
+    ```
     in `main()` in `main.c`, and change the file name to the SWIFT parameter
     file that you intend to use for your simulation.
 
 3)  define how many photon groups you are planning to run the simulation 
-    with at the top of the file `main.c`, e.g. `#define RT_NGROUPS 4`
+    with at the top of the file `main.c`, e.g. `#define RT_NGROUPS 3`
 
 4)  Compile and run the test suite using `run.sh`
 

--- a/GEARRTUnitCheck/generate_simulation_parameter_file.py
+++ b/GEARRTUnitCheck/generate_simulation_parameter_file.py
@@ -91,7 +91,7 @@ max_sml = np.max(sml)
 
 # Read in radiation data
 has_photon_group = True
-radiation_sum = 0.
+radiation_sum = 0.0
 group = 0
 
 while has_photon_group:
@@ -106,10 +106,10 @@ while has_photon_group:
         has_photon_group = False
         break
 average_radiation = radiation_sum / npart
-if average_radiation == 0.:
-    min_radiation = 0.
-    max_radiation = 0.
-print("Found", group-1, "photon group ICs")
+if average_radiation == 0.0:
+    min_radiation = 0.0
+    max_radiation = 0.0
+print("Found", group - 1, "photon group ICs")
 
 
 # dump yaml file
@@ -144,9 +144,9 @@ with open("simulation_parameters.yml", "w") as file:
         "maxDensity": max_density,
         "averageDensity": average_density,
         "smoothingLength": smoothing_length,
-        "minRadiationEnergy": min_radiation, 
-        "maxRadiationEnergy": max_radiation, 
-        "averageRadiationEnergy": average_radiation, 
+        "minRadiationEnergy": min_radiation,
+        "maxRadiationEnergy": max_radiation,
+        "averageRadiationEnergy": average_radiation,
     }
 
     units_dict = {

--- a/GEARRTUnitCheck/generate_simulation_parameter_file.py
+++ b/GEARRTUnitCheck/generate_simulation_parameter_file.py
@@ -26,7 +26,9 @@ length_units = 0.0
 velocity_units = 0.0
 current_units = 0.0
 temperature_units = 0.0
-
+min_radiation = sys.float_info.max
+max_radiation = 0.0
+average_radiation = 0.0
 
 try:
     inputfile = sys.argv[1]
@@ -87,6 +89,29 @@ smoothing_length = np.sum(sml) / npart
 min_sml = np.min(sml)
 max_sml = np.max(sml)
 
+# Read in radiation data
+has_photon_group = True
+radiation_sum = 0.
+group = 0
+
+while has_photon_group:
+    group += 1
+    dsetname = "photon_energies_group{0:d}".format(group)
+    try:
+        rad_group = getattr(gas, dsetname)
+        radiation_sum += rad_group.sum()
+        min_radiation = min(min_radiation, rad_group.min())
+        max_radiation = max(max_radiation, rad_group.max())
+    except AttributeError:
+        has_photon_group = False
+        break
+average_radiation = radiation_sum / npart
+if average_radiation == 0.:
+    min_radiation = 0.
+    max_radiation = 0.
+print("Found", group-1, "photon group ICs")
+
+
 # dump yaml file
 with open("simulation_parameters.yml", "w") as file:
 
@@ -101,6 +126,9 @@ with open("simulation_parameters.yml", "w") as file:
     min_density = float(min_density)
     max_density = float(max_density)
     average_density = float(average_density)
+    min_radiation = float(min_radiation)
+    max_radiation = float(max_radiation)
+    average_radiation = float(average_radiation)
     smoothing_length = float(smoothing_length)
     boxsize = float(boxsize)
     npart = int(npart)
@@ -116,7 +144,11 @@ with open("simulation_parameters.yml", "w") as file:
         "maxDensity": max_density,
         "averageDensity": average_density,
         "smoothingLength": smoothing_length,
+        "minRadiationEnergy": min_radiation, 
+        "maxRadiationEnergy": max_radiation, 
+        "averageRadiationEnergy": average_radiation, 
     }
+
     units_dict = {
         "UnitMass_in_cgs": mass_units,
         "UnitLength_in_cgs": length_units,

--- a/GEARRTUnitCheck/include/grackle_heating_test.h
+++ b/GEARRTUnitCheck/include/grackle_heating_test.h
@@ -34,18 +34,22 @@
  * quantity * units = quantity_in_cgs
  *
  * @param density gas density to use
+ * @param fixed_radiation_density_field_cgs fixed energy density to use as heating source, in erg/cm^3/s
  * @param name name of the test case. NO SPACES.
  * @param mass_units the internal mass units to use.
  * @param length_units the internal length units to use.
  * @param density_units the internal density units to use.
  * @param velocity_units the internal velocity units to use.
  * @param internal_energy_units the internal specific internal energy units
+ * @param dump_results whether to write results to file
  * @param verbose print time step data to screen?
  **/
-void run_grackle_heating_test(float density, char *name, double mass_units,
+void run_grackle_heating_test(float density, double fixed_radiation_density_field_cgs[RT_NGROUPS], char *name, double mass_units,
                               double length_units, double time_units,
                               double density_units, double velocity_units,
-                              double internal_energy_units, int verbose) {
+                              double internal_energy_units, 
+                              int dump_results, 
+                              int verbose) {
 
   /******************************************************************
    * Set up initial conditions and runtime parameters.
@@ -56,7 +60,8 @@ void run_grackle_heating_test(float density, char *name, double mass_units,
   /* output file */
   char filename[200];
   sprintf(filename, "heating_test-%s.dat", name);
-  FILE *fd = fopen(filename, "w");
+  FILE *fd = NULL;
+  if (dump_results) fd = fopen(filename, "w");
   /* output frequency  in number of steps */
   int output_frequency_cool = 64; /* output frequency while cooling */
   int output_frequency_heat = 2;  /* output frequency while heating */
@@ -79,23 +84,6 @@ void run_grackle_heating_test(float density, char *name, double mass_units,
   /* --------------------------------------- */
   double hydrogen_fraction_by_mass = 1.00;
   double gas_density = density;
-
-  /* Initial conditions for radiation */
-#if RT_NGROUPS == 4
-  /* Fixed luminosity to heat the gas. In erg / cm^2 / s */
-  double fixed_luminosity_cgs[4] = {0., 1.350e+01, 2.779e+01, 6.152e+00};
-#elif RT_NGROUPS == 1
-  /* Fixed luminosity to heat the gas. In erg / cm^2 / s */
-  double fixed_luminosity_cgs[1] = {4.774e+01};
-#else
-  error("You need to set up the correct frequency bins and luminosities "
-        "for " RT_NGROUPS " groups used");
-#endif
-  double fixed_radiation_density_field_cgs[4] = {0., 0., 0., 0.};
-  for (int g = 0; g < RT_NGROUPS; g++) {
-    fixed_radiation_density_field_cgs[g] =
-        fixed_luminosity_cgs[g] / const_speed_light_c;
-  }
 
   /* Derived quantities from ICs */
   /* --------------------------- */
@@ -147,23 +135,20 @@ void run_grackle_heating_test(float density, char *name, double mass_units,
   /* Get photon cross sections and mean energies */
   /* ------------------------------------------- */
 
-#if RT_NGROUPS == 4
+#if RT_NGROUPS == 3
   /* Just store the solutions, don't mind the computation for this test.
    * It's always done in cgs, so that shouldn't fail regardless of user
    * chosen units. */
   /* Cross sections are in cm^-2, mean photon energies in erg. */
-  double cse_0[3] = {0., 0., 0.};
-  double cse_1[3] = {2.782672e-18, 0., 0.};
-  double cse_2[3] = {5.043639e-19, 6.020192e-24, 0.};
-  double cse_3[3] = {7.459092e-20, 6.515781e-25, 1.002143e-18};
-  double *cse[RT_NGROUPS] = {cse_0, cse_1, cse_2, cse_3};
-  double csn_0[3] = {0., 0., 0.};
-  double csn_1[3] = {3.007890e-18, 0., 0.};
-  double csn_2[3] = {5.688884e-19, 6.901561e-24, 0.};
-  double csn_3[3] = {7.893315e-20, 6.929928e-25, 1.056205e-18};
-  double *csn[RT_NGROUPS] = {csn_0, csn_1, csn_2, csn_3};
-  double mean_photon_energies[RT_NGROUPS] = {1.337e-11, 3.020e-11, 5.619e-11,
-                                             1.052e-10};
+  double cse_0[3] = {2.782672e-18, 0., 0.};
+  double cse_1[3] = {5.043639e-19, 6.020192e-24, 0.};
+  double cse_2[3] = {7.459092e-20, 6.515781e-25, 1.002143e-18};
+  double *cse[RT_NGROUPS] = {cse_0, cse_1, cse_2};
+  double csn_0[3] = {3.007890e-18, 0., 0.};
+  double csn_1[3] = {5.688884e-19, 6.901561e-24, 0.};
+  double csn_2[3] = {7.893315e-20, 6.929928e-25, 1.056205e-18};
+  double *csn[RT_NGROUPS] = {csn_0, csn_1, csn_2};
+  double mean_photon_energies[RT_NGROUPS] = {3.020e-11, 5.619e-11, 1.052e-10};
 #elif RT_NGROUPS == 1
   double cse_0[3] = {1.096971e-18, 2.303147e-24, 1.298503e-19};
   double *cse[RT_NGROUPS] = {cse_0};
@@ -254,13 +239,15 @@ void run_grackle_heating_test(float density, char *name, double mass_units,
   }
 
   /* write down what ICs you used into file */
-  write_my_setup(fd, grackle_fields, grackle_chemistry_data, mass_units,
-                 length_units, velocity_units, dt_max_heat,
-                 hydrogen_fraction_by_mass, gas_density, internal_energy);
-  write_header(fd);
-  write_timestep(fd, &grackle_fields, &grackle_units_data,
-                 &grackle_chemistry_data, /*field_index=*/0, t, dt_max_heat,
-                 time_units, /*step=*/0);
+  if (dump_results){
+    write_my_setup(fd, grackle_fields, grackle_chemistry_data, mass_units,
+                   length_units, velocity_units, dt_max_heat,
+                   hydrogen_fraction_by_mass, gas_density, internal_energy);
+    write_header(fd);
+    write_timestep(fd, &grackle_fields, &grackle_units_data,
+                   &grackle_chemistry_data, /*field_index=*/0, t, dt_max_heat,
+                   time_units, /*step=*/0);
+  }
 
   /*********************************************************************
   / Calling the chemistry solver
@@ -329,14 +316,14 @@ void run_grackle_heating_test(float density, char *name, double mass_units,
       }
     }
 
-    if (step % output_frequency_to_use == 0)
+    if (step % output_frequency_to_use == 0 && dump_results)
       write_timestep(fd, &grackle_fields, &grackle_units_data,
                      &grackle_chemistry_data, /*field_index=*/0, t, dt,
                      time_units, step);
   }
 
   /* Cleanup */
-  fclose(fd);
+  if (dump_results) fclose(fd);
   clean_up_fields(&grackle_fields);
   _free_chemistry_data(&grackle_chemistry_data, &grackle_rates);
 

--- a/GEARRTUnitCheck/include/grackle_heating_test.h
+++ b/GEARRTUnitCheck/include/grackle_heating_test.h
@@ -34,7 +34,8 @@
  * quantity * units = quantity_in_cgs
  *
  * @param density gas density to use
- * @param fixed_radiation_density_field_cgs fixed energy density to use as heating source, in erg/cm^3/s
+ * @param fixed_radiation_density_field_cgs fixed energy density to use as
+ *heating source, in erg/cm^3/s
  * @param name name of the test case. NO SPACES.
  * @param mass_units the internal mass units to use.
  * @param length_units the internal length units to use.
@@ -44,12 +45,11 @@
  * @param dump_results whether to write results to file
  * @param verbose print time step data to screen?
  **/
-void run_grackle_heating_test(float density, double fixed_radiation_density_field_cgs[RT_NGROUPS], char *name, double mass_units,
-                              double length_units, double time_units,
-                              double density_units, double velocity_units,
-                              double internal_energy_units, 
-                              int dump_results, 
-                              int verbose) {
+void run_grackle_heating_test(
+    float density, double fixed_radiation_density_field_cgs[RT_NGROUPS],
+    char *name, double mass_units, double length_units, double time_units,
+    double density_units, double velocity_units, double internal_energy_units,
+    int dump_results, int verbose) {
 
   /******************************************************************
    * Set up initial conditions and runtime parameters.
@@ -61,7 +61,8 @@ void run_grackle_heating_test(float density, double fixed_radiation_density_fiel
   char filename[200];
   sprintf(filename, "heating_test-%s.dat", name);
   FILE *fd = NULL;
-  if (dump_results) fd = fopen(filename, "w");
+  if (dump_results)
+    fd = fopen(filename, "w");
   /* output frequency  in number of steps */
   int output_frequency_cool = 64; /* output frequency while cooling */
   int output_frequency_heat = 2;  /* output frequency while heating */
@@ -239,7 +240,7 @@ void run_grackle_heating_test(float density, double fixed_radiation_density_fiel
   }
 
   /* write down what ICs you used into file */
-  if (dump_results){
+  if (dump_results) {
     write_my_setup(fd, grackle_fields, grackle_chemistry_data, mass_units,
                    length_units, velocity_units, dt_max_heat,
                    hydrogen_fraction_by_mass, gas_density, internal_energy);
@@ -323,7 +324,8 @@ void run_grackle_heating_test(float density, double fixed_radiation_density_fiel
   }
 
   /* Cleanup */
-  if (dump_results) fclose(fd);
+  if (dump_results)
+    fclose(fd);
   clean_up_fields(&grackle_fields);
   _free_chemistry_data(&grackle_chemistry_data, &grackle_rates);
 

--- a/GEARRTUnitCheck/plot_cooling_tests.py
+++ b/GEARRTUnitCheck/plot_cooling_tests.py
@@ -22,9 +22,9 @@ ax4 = fig.add_subplot(2, 2, 4)
 
 colors = ["C0", "C4", "C3"]
 
-for i, sim in enumerate(["average", "min", "max"]):
+for i, sim in enumerate(["av", "min", "max"]):
 
-    resultfile = "cooling_test-density_" + sim + ".dat"
+    resultfile = "cooling_test-rho_" + sim + ".dat"
 
     # Read in units.
     f = open(resultfile, "r")

--- a/GEARRTUnitCheck/plot_heating_tests.py
+++ b/GEARRTUnitCheck/plot_heating_tests.py
@@ -22,9 +22,9 @@ ax4 = fig.add_subplot(2, 2, 4)
 
 colors = ["C0", "C4", "C3"]
 
-for i, sim in enumerate(["average", "min", "max"]):
+for i, sim in enumerate(["av", "min", "max"]):
 
-    resultfile = "heating_test-density_" + sim + ".dat"
+    resultfile = "heating_test-rho_" + sim + ".dat"
 
     # Read in units.
     f = open(resultfile, "r")

--- a/GEARRTUnitCheck/run.sh
+++ b/GEARRTUnitCheck/run.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# quit if something fails
+set -e
+
 make clean
 make
 ./GEARRT_unit_checks

--- a/GEARRTUnitCheck/simulation_parameters_example.yml
+++ b/GEARRTUnitCheck/simulation_parameters_example.yml
@@ -2,11 +2,14 @@
 
 # Particle related quantities
 ParticleData:
-  ParticleMass: 1.      # particle mass (in internal units)
-  minDensity: 0.        # (estimate of) minimal density in simulation (in internal units)
-  maxDensity: 0.        # (estimate of) maximal density in simulation (in internal units)
-  averageDensity: 0.    # average density in simulation (in internal units). NOTE: if = 0., the code will try to compute its own average density based on boxsize, particle mass, and particle number, and try min/max densities with a factor of 10^{+-3}
-  smoothingLength: 1.   # (estimate of) typical smoothing length (in internal units). If = 0., the code will try to compute its own estimate.
+  ParticleMass: 1.                  # particle mass (in internal units)
+  minDensity: 0.                    # (estimate of) minimal density in simulation (in internal units)
+  maxDensity: 0.                    # (estimate of) maximal density in simulation (in internal units)
+  averageDensity: 0.                # average density in simulation (in internal units). NOTE: if = 0., the code will try to compute its own average density based on boxsize, particle mass, and particle number, and try min/max densities with a factor of 10^{+-3}
+  smoothingLength: 1.               # (estimate of) typical smoothing length (in internal units). If = 0., the code will try to compute its own estimate.
+  minRadiationEnergyDensity: 0.     # minimal radiation energy density (of any photon group) present in ICs.
+  maxRadiationEnergyDensity: 0.     # maximal radiation energy density (of any photon group) present in ICs.
+  averageRadiationEnergyDensity: 0. # average radiation energy density (of any photon group) present in ICs.
 
 # global data
 GlobalData:

--- a/GEARRTUnitCheck/src/main.c
+++ b/GEARRTUnitCheck/src/main.c
@@ -9,7 +9,7 @@
 /* #include <fenv.h>  */
 
 /* define these before including local headers like my_grackle_utils.h */
-#define RT_NGROUPS 4
+#define RT_NGROUPS 3
 /* Grackle related macros */
 #define FIELD_SIZE 1
 #include "my_grackle_utils.h"
@@ -31,34 +31,43 @@
 /* --------------------- */
 
 /* Units to be used in the swift simulation */
-double mass_units;
-double time_units;
-double length_units;
-double density_units;
-double velocity_units;
-double temperature_units;
-double energy_units;
-double internal_energy_units;
+double mass_units = 0.;
+double time_units = 0.;
+double length_units = 0.;
+double density_units = 0.;
+double velocity_units = 0.;
+double temperature_units = 0.;
+double internal_energy_units = 0.;
+double energy_units = 0.;
+double energy_density_units = 0.;
+double power_units = 0.;
 
 /* Radiation variables */
-float c_reduced; /* in internal units */
-double *star_emission_rates;
-double *photon_groups_Hz;
+float c_reduced = 0.; /* in internal units */
+double *star_emission_rates = NULL;
+double *photon_groups_Hz = NULL;
+int use_const_emission_rates = 0.;
 
 /* Other quantities. All assumed in SWIFT internal units. */
-float particle_mass;
+float particle_mass = 0.f;
 /* (Estimate of) minimal density in sim */
-float density_min;
+float density_min = 0.f;
 /* (Estimate of) maximal density in sim */
-float density_max;
+float density_max = 0.f;
 /* Average density in sim */
-float density_average;
+float density_average = 0.f;
 /* boxsize */
-float boxsize;
+float boxsize = 0.f;
 /* (Estimate of) smoothing length */
-float smoothing_length;
+float smoothing_length = 0.f;
+/* Minimal radiation energy (not density) in ICs */
+float rad_energy_min = 0.f;
+/* Maximal radiation energy (not density) in ICs */
+float rad_energy_max = 0.f;
+/* Average radiation energy (not density) in ICs */
+float rad_energy_av = 0.f;
 /* Number of gas particles in simulation */
-long long npart;
+long long npart = 0.l;
 
 int warnings = 0;
 
@@ -186,6 +195,43 @@ int warnings = 0;
   })
 
 /**
+ * @brief estimate a time step size.
+ * @return time step in internal units.
+ **/
+float estimate_dt(void){
+  if (smoothing_length == 0.) error("sml=0?");
+  if (c_reduced == 0.) error("c_red=0?");
+  return smoothing_length / c_reduced;
+}
+
+/** 
+ * @brief Get an estimate for the injected radiation energy density
+ * from a given luminosity.
+ * 
+ * @param luminosity luminosity in units of solar luminosities
+ * @return the radiation energy density in internal units.
+ *
+ **/
+float radiation_energy_density_from_luminosity(double luminosity){
+
+  /* To obtain some energy density, set E = L * dt / V
+   * If you want to vary particle volume, you should also vary dt
+   * by the same factor according to the CFL logic. This means
+   * however that the factor to modify dt and V cancels out since
+   * we need dt/V, so no reason to check several scenarios there. */
+
+  const double partV = boxsize * boxsize * boxsize / (double) npart;
+  check_valid_float(partV, 0);
+  const double dt = estimate_dt();
+  check_valid_float(dt, 0);
+  float rad_energy_density = luminosity * const_L_Sun / power_units * dt / partV;
+  check_valid_float(rad_energy_density, 0);
+
+  return rad_energy_density;
+}
+
+
+/**
  * @brief Read in the parameters relevant for this check.
  *
  * @param params (return) swift_params struct to be filled
@@ -215,29 +261,37 @@ void read_swift_params(struct swift_params *params) {
 
   float fc = parser_get_param_float(params, "GEARRT:f_reduce_c");
   c_reduced = fc * const_speed_light_c / velocity_units;
-  star_emission_rates = malloc(RT_NGROUPS * sizeof(double));
-  double *photon_groups_read = malloc(RT_NGROUPS * sizeof(double));
-  parser_get_param_double_array(params, "GEARRT:star_emission_rates_LSol",
-                                RT_NGROUPS, star_emission_rates);
+  photon_groups_Hz = malloc(RT_NGROUPS * sizeof(double));
   if (RT_NGROUPS == 0) {
     error(
         "Can't run RT with 0 photon groups. Modify RT_NGROUPS in this script.");
-  } else if (RT_NGROUPS == 1) {
-    photon_groups_read[0] = 0.;
   } else {
     parser_get_param_double_array(params, "GEARRT:photon_groups_Hz",
-                                  RT_NGROUPS - 1, photon_groups_read);
+                                  RT_NGROUPS, photon_groups_Hz);
   }
-  photon_groups_Hz = malloc(RT_NGROUPS * sizeof(double));
-  for (int i = 0; i < RT_NGROUPS - 1; i++) {
-    photon_groups_Hz[i + 1] = photon_groups_read[i];
-  }
-  photon_groups_Hz[0] = 0.;
 
+  use_const_emission_rates = parser_get_opt_param_int(
+      params, "GEARRT:use_const_emission_rates", /* default = */ 0);
+  star_emission_rates = malloc(RT_NGROUPS * sizeof(double));
+  if (use_const_emission_rates) {
+    parser_get_param_double_array(params, "GEARRT:star_emission_rates_LSol",
+                                  RT_NGROUPS, star_emission_rates);
+  } else {
+    error("This check isn't set up to run without constant stellar emission rates (yet)");
+  }
+}
+
+/**
+ * @brief get additional internal unit conversions
+ **/
+void get_internal_units(void){
   /* Convert units */
+  const double volume_units = (length_units * length_units * length_units);
+  check_valid_double(volume_units, 0);
+
   time_units = length_units / velocity_units;
   check_valid_float(time_units, 0);
-  density_units = mass_units / (length_units * length_units * length_units);
+  density_units = mass_units / volume_units;
   check_valid_float(density_units, 0);
   internal_energy_units = velocity_units * velocity_units;
   check_valid_float(internal_energy_units, 0);
@@ -246,10 +300,18 @@ void read_swift_params(struct swift_params *params) {
    * limits, but that's not an issue because the energy itself can be very
    * high too. So in the end, it works out. */
   /* check_valid_float(energy_units, 0); */
+  /* Nonetheless, print a warning for now. */
+  if (energy_units != 0. && (fabs(energy_units) > 1e30 || fabs(energy_units) < 1e-30)) {  
+    fprintf(stdout, "WARNING: %s:%s:%d: energy units has large exponent: %.6e\n", __FILE__, __FUNCTION__, __LINE__, energy_units); 
+    warnings++;
+  }
 
-  /* Clean up */
-  free(photon_groups_read);
+  energy_density_units = energy_units / volume_units;
+  check_valid_float(energy_density_units, 0);
+  power_units = energy_units / time_units;
+  check_valid_float(power_units, 0);
 }
+
 /**
  * @brief Read in the parameters from the ICs relevant for this check.
  *
@@ -261,30 +323,38 @@ void read_ic_params(struct swift_params *params) {
       parser_get_param_double(params, "InternalUnitSystem:UnitMass_in_cgs");
   const double length_units_ic =
       parser_get_param_double(params, "InternalUnitSystem:UnitLength_in_cgs");
-  /* const double velocity_units_ic = parser_get_param_double(params,
-   * "InternalUnitSystem:UnitVelocity_in_cgs"); */
+  const double velocity_units_ic = parser_get_param_double(params,
+  "InternalUnitSystem:UnitVelocity_in_cgs");
   /* const double temperature_units_ic = parser_get_param_double(params,
    * "InternalUnitSystem:UnitTemp_in_cgs"); */
   const double density_units_ic =
       mass_units_ic / (length_units_ic * length_units_ic * length_units_ic);
+  const double energy_units_ic = mass_units_ic * velocity_units_ic * velocity_units_ic;
 
   const float particle_mass_ic =
       parser_get_param_float(params, "ParticleData:ParticleMass");
   const float av_density_ic =
       parser_get_param_float(params, "ParticleData:averageDensity");
+  const float av_radiation_ic = 
+      parser_get_param_float(params, "ParticleData:averageRadiationEnergy");
   const float boxsize_ic = parser_get_param_float(params, "GlobalData:boxsize");
   npart = parser_get_param_longlong(params, "GlobalData:npart");
 
   /* Convert quantities from IC internal units to SWIFT internal units */
   message("Converting IC units to SWIFT run units");
   particle_mass = particle_mass_ic * mass_units_ic / mass_units;
-  check_valid_float(particle_mass, 1);
+  check_valid_float(particle_mass, 0);
 
   density_average = av_density_ic * density_units_ic / density_units;
   check_valid_float(density_average, 0);
+  if (density_average > 0.) check_valid_float(density_average, 1);
+
+  rad_energy_av = av_radiation_ic * energy_units_ic / energy_units;
+  if (rad_energy_av != 0.) check_valid_float(rad_energy_av, 0);
+  if (rad_energy_av < 0.) error("Average radiation energy = %.3g < 0", rad_energy_av);
 
   boxsize = boxsize_ic * length_units_ic / length_units;
-  check_valid_float(boxsize, 0);
+  check_valid_float(boxsize, 1);
   if (boxsize == 0.)
     error("Got 0. boxsize?");
 
@@ -325,17 +395,27 @@ void read_ic_params(struct swift_params *params) {
   if (sml_ic == 0.) {
     /* Try and estimate yourself */
     smoothing_length = 0.75 * boxsize / pow(npart, 0.3333333);
-    check_valid_float(smoothing_length, 1);
+    check_valid_float(smoothing_length, 0);
   } else {
     smoothing_length = sml_ic * length_units_ic / length_units;
-    check_valid_float(smoothing_length, 1);
+    check_valid_float(smoothing_length, 0);
+  }
+
+  rad_energy_min = 0.f;
+  rad_energy_max = 0.f;
+  if (rad_energy_av > 0.) {
+    const double rad_energy_max_ic = 
+      parser_get_param_float(params, "ParticleData:maxRadiationEnergy");
+    rad_energy_max = rad_energy_max_ic * energy_units_ic / energy_units;
+    const double rad_energy_min_ic = 
+      parser_get_param_float(params, "ParticleData:minRadiationEnergy");
+    rad_energy_min = rad_energy_min_ic * energy_units_ic / energy_units;
   }
 }
 
 /**
  * @brief print out the used parameters for a visual inspection
  **/
-
 void print_params() {
 
   message("Units: [in cgs]");
@@ -356,12 +436,9 @@ void print_params() {
   message("%22s: %.6e", "density_max", density_max);
   message("%22s: %.6e", "boxsize", boxsize);
   message("%22s: %.6e", "smoothing length", smoothing_length);
-  message("%22s: %.6e", "approx dt [internal units]",
-          smoothing_length / c_reduced);
-  message("%22s: %.6e", "approx dt [s]             ",
-          smoothing_length / c_reduced * time_units);
-  message("%22s: %.6e", "approx dt [kyr]           ",
-          smoothing_length / c_reduced * time_units / const_yr * 1e-3);
+  message("%22s: %.6e", "approx dt [internal units]", estimate_dt());
+  message("%22s: %.6e", "approx dt [s]             ", estimate_dt() / time_units);
+  message("%22s: %.6e", "approx dt [kyr]           ", estimate_dt() * time_units / const_yr * 1e-3);
 }
 
 /**
@@ -377,7 +454,7 @@ void check_gas_quantities(float density, char *name, float T, int verbose) {
 
   /* assume mean molecular weight of 1 for this test. While that isn't correct,
    * it should do the trick for the purpose of this test. */
-  message("Checking gas quantities for T=%.1e case=%s", T, name);
+  message("Checking T=%.1e case=%s", T, name);
 
   const float gamma = const_adiabatic_index;
   const float gamma_minus_one = gamma - 1.f;
@@ -453,13 +530,14 @@ void check_gas_quantities(float density, char *name, float T, int verbose) {
  * grackle internally have valid values.
  *
  * @param density gas density to use
+ * @param radiation_energy_density radiation energy density to use
  * @param name name of the test case. NO SPACES.
  * @param T temperature to deal with
  * @param verbose are we talkative?
  **/
-void check_grackle_internals(float density, char *name, float T, int verbose) {
+void check_grackle_internals(float density, float radiation_energy_density, char *name, float T, int verbose) {
 
-  message("Checking grackle internals for T=%.1e case=%s", T, name);
+  message("checking %s, T=%.1e", name, T);
 
   /* Check that the total number density is within the valid limits for
    * grackle to handle. */
@@ -533,15 +611,13 @@ void check_grackle_internals(float density, char *name, float T, int verbose) {
     const double cse = 1.096971e-18;
     const double csn = 1.630511e-18;
     const double mean_photon_energy = 4.744e-11;   /* erg */
-    const double fixed_luminosity_cgs = 4.774e+01; /* erg/s/cm^2 */
     const double E_ion = 2.179e-11; /* erg, ionization energy of hydrogen */
 
-    const double Ei = fixed_luminosity_cgs / const_speed_light_c;
-    const double Eic = Ei * const_speed_light_c;
+    const double Eic = radiation_energy_density * const_speed_light_c;
     const double Nic = Eic / mean_photon_energy;
 
-    check_valid_double(Eic, 1);
-    check_valid_double(Nic, 1);
+    check_valid_double(Eic, 0);
+    check_valid_double(Nic, 0);
 
     const double number_density_units = density_units / const_mh;
     check_valid_double(number_density_units, 0);
@@ -589,6 +665,73 @@ void check_grackle_internals(float density, char *name, float T, int verbose) {
   check_doubles_equal(heating_rates[1], heating_rates[2]);
 }
 
+
+/**
+ * @brief Check whether other gas quantities derived from the
+ * initial conditions are within an acceptable range
+ *
+ * @param radEnergy radiation energy to use
+ * @param radName name of the test case. NO SPACES.
+ * @param density gas density to use
+ * @param name name of the test case. NO SPACES.
+ * @param T temperature to deal with
+ * @param verbose are we talkative?
+ **/
+void check_radiation_energies(float radEnergy, char *radName, float density, char *name, float T, int verbose) {
+
+  const double mean_particle_volume = boxsize * boxsize * boxsize / (double) npart;
+  double volumes[3] = {mean_particle_volume, 1.e-3 * mean_particle_volume, 1.e3 * mean_particle_volume};
+  char *vnames[3] = {"V_av", "V_min", "V_max"};
+
+  char fullname[80] = "E_rad:";
+  strcat(fullname, radName);
+  strcat(fullname, ", ");
+  strcat(fullname, name);
+  if (radEnergy == 0.) {
+    message("radiation energy = 0 case %s; skipping.", fullname);
+    return;
+  }
+
+  for (int v = 0; v < 3; v++) {
+    strcpy(fullname, "E_rad:");
+    strcat(fullname, radName);
+    strcat(fullname, ", ");
+    strcat(fullname, name);
+    strcat(fullname, ", ");
+    strcat(fullname, vnames[v]);
+
+
+    const double partV = volumes[v];
+    const double rad_energy_density = radEnergy / partV;
+    check_valid_float(rad_energy_density, 0);
+
+    check_grackle_internals(density, rad_energy_density, fullname, T, verbose);
+  }
+}
+
+/**
+ * @brief Check whether other gas quantities derived from the
+ * initial conditions are within an acceptable range
+ *
+ * @param density gas density to use
+ * @param name name of the test case. NO SPACES.
+ * @param T temperature to deal with
+ * @param verbose are we talkative?
+ **/
+void check_luminosities(float luminosity, float density, char *name, float T, int verbose) {
+
+  char fullname[80];
+  sprintf(fullname, "luminosities: L=%.3g, %s", luminosity, name);
+
+  if (luminosity == 0.) {
+    message("luminosity = 0 case %s; skipping.", fullname);
+    return;
+  }
+
+  float rad_energy_density = radiation_energy_density_from_luminosity(luminosity);
+  check_grackle_internals(density, rad_energy_density, fullname, T, verbose);
+}
+
 int main(void) {
 
   /* FPE's, here we come! */
@@ -601,8 +744,14 @@ int main(void) {
   /* ----------------------------------------- */
 
   /* TODO: make this a cmdline arg? */
-  char *swift_param_filename = "swift_parameters.yml";
-  char *sim_param_filename = "simulation_parameters.yml";
+  /* This needs to be the parameter filename that you plan
+   * on running SWIFT with for your simulation */
+  /* char *sim_run_params_filename = "swift_parameters.yml"; */
+  char *sim_run_params_filename = "stromgrenSphere-3D.yml";
+  /* This is the parameter filename for the params that you
+   * either set up manually or extracted from the ICs using
+   * the provided script. */
+  char *IC_params_filename = "simulation_parameters.yml";
 
   /* Print a lot of information to the screen? */
   int verbose = 0;
@@ -610,13 +759,15 @@ int main(void) {
   /* Read the SWIFT parameter file, and the parameters */
   struct swift_params *swift_params =
       (struct swift_params *)malloc(sizeof(struct swift_params));
-  read_paramfile(swift_params, swift_param_filename);
+  read_paramfile(swift_params, sim_run_params_filename);
   read_swift_params(swift_params);
+  /* Get additional internal unit conversions before we continue */
+  get_internal_units();
 
   /* Read the simulation data parameter file, and the parameters */
   struct swift_params *sim_params =
       (struct swift_params *)malloc(sizeof(struct swift_params));
-  read_paramfile(sim_params, sim_param_filename);
+  read_paramfile(sim_params, IC_params_filename);
   read_ic_params(sim_params);
 
   /* Print out the units and parameters for a visual inspection */
@@ -625,8 +776,8 @@ int main(void) {
   /* ------------------------*/
   /* Prepare to run examples */
   /* ------------------------*/
-  /* If the min/max densities are too close to the average, re-size them */
 
+  /* If the min/max densities are too close to the average, re-size them */
   if (fabs(1. - density_min / density_average) < 0.05) {
     message("density_min too close to average. Resizing %.3e -> %.3e",
             density_min, 0.8 * density_average);
@@ -640,21 +791,73 @@ int main(void) {
     check_valid_float(density_max, 1);
   }
 
+  /* If the min/max densities are too close to the average, re-size them */
+  if (rad_energy_av > 0.) {
+    if (rad_energy_min / rad_energy_av > 1.e-3) {
+      message("photon energy_min too close to average. Resizing %.3e -> %.3e",
+              rad_energy_min, 1.e-3 * rad_energy_av);
+      rad_energy_min = 1.e-3 * rad_energy_av;
+      check_valid_float(rad_energy_min, 0);
+    }
+    if (rad_energy_max / rad_energy_av < 1.e3) {
+      message("photon energy_max too close to average. Resizing %.3e -> %.3e",
+              rad_energy_max, 1.e3 * rad_energy_av);
+      rad_energy_max = 1.e3 * rad_energy_av;
+      check_valid_float(rad_energy_max, 0);
+    }
+  }
+
+  /* Set up arrays to loop over */
   float dens_arr[3] = {density_average, density_min, density_max};
-  char *dens_names[3] = {"density_average", "density_min", "density_max"};
+  char *dens_names[3] = {"rho_av", "rho_min", "rho_max"};
   float T_test[7] = {10., 100., 1000., 1.e4, 1.e5, 1.e6, 1.e7};
+
+  float rad_arr[3] = {rad_energy_av, rad_energy_min, rad_energy_max};
+  char *rad_names[3] = {"Erad_av", "Erad_min", "Erad_max"};
 
   /* Run Gas Quantities Checks */
   /* ------------------------- */
+  /* Set up some radiation energy density. 4.774e+01 erg/s/cm^2 corresponds
+   * to a blackbody spectrum with T=10^5K and Ndot = 10^12 photons/s */
+  const double fixed_luminosity_gas_check_cgs = 4.774e+01; /* erg/s/cm^2 */
+  const double Ei = fixed_luminosity_gas_check_cgs / const_speed_light_c;
   for (int d = 0; d < 3; d++) {
     float rho = dens_arr[d];
     char *name = dens_names[d];
     for (int t = 0; t < 7; t++) {
       float T = T_test[t];
       check_gas_quantities(rho, name, T, verbose);
-      check_grackle_internals(rho, name, T, verbose);
+      check_grackle_internals(rho, Ei, name, T, verbose);
     }
   }
+
+  /* Run Radiation Quantities Checks */
+  /* ------------------------------- */
+  /* Check radiation energies only if there are some present
+   * in the ICs. The radiation energies resulting from injection
+   * from stars will be checked with check_luminosities() */
+  for (int d = 0; d < 3; d++) {
+    float rho = dens_arr[d];
+    char *name = dens_names[d];
+
+    for (int t = 0; t < 7; t++) {
+      float T = T_test[t];
+
+      for (int e = 0; e < 3; e++){
+        float radEnergy = rad_arr[e];
+        char *radName = rad_names[e];
+        if (rad_energy_av > 0.)
+          check_radiation_energies(radEnergy, radName, rho, name, T, verbose);
+      }
+
+      for (int g = 0; g < RT_NGROUPS; g++) {
+        float l = star_emission_rates[g];
+        check_luminosities(l, rho, name, T, verbose);
+      }
+
+    }
+  }
+
 
   /* Run Grackle cooling test */
   /* ------------------------ */
@@ -666,17 +869,51 @@ int main(void) {
                              internal_energy_units, verbose);
   }
 
+  /* Initial conditions for radiation */
+#if RT_NGROUPS == 3
+  /* Fixed luminosity to heat the gas. In erg / cm^2 / s */
+  double L_heating_test_cgs[3] = {1.350e+01, 2.779e+01, 6.152e+00};
+#elif RT_NGROUPS == 1
+  /* Fixed luminosity to heat the gas. In erg / cm^2 / s */
+  double L_heating_test_cgs[1] = {4.774e+01};
+#else
+#error Only RT_NGROUPS = [1, 3] implemented for now
+#endif
+  double Erad_heating_test_cgs[RT_NGROUPS];
+  for (int g = 0; g < RT_NGROUPS; g++) {
+    Erad_heating_test_cgs[g] = L_heating_test_cgs[g] / const_speed_light_c;
+    check_valid_double(Erad_heating_test_cgs[g], 0);
+  }
+
+  double Erad_luminosity_test_cgs[RT_NGROUPS]; 
+  for (int g = 0; g < RT_NGROUPS; g++) {
+    Erad_luminosity_test_cgs[g] = radiation_energy_density_from_luminosity(star_emission_rates[g]);
+    Erad_luminosity_test_cgs[g] *= energy_density_units;
+    check_valid_double(Erad_luminosity_test_cgs[g], 0);
+  }
+
+
   /* Run Grackle heating test */
   /* ------------------------ */
   for (int d = 0; d < 3; d++) {
     float rho = dens_arr[d];
     char *name = dens_names[d];
-    run_grackle_heating_test(rho, name, mass_units, length_units, time_units,
-                             density_units, velocity_units,
-                             internal_energy_units, verbose);
+    run_grackle_heating_test(rho, Erad_heating_test_cgs, name, mass_units, length_units, time_units, density_units, velocity_units, internal_energy_units, /*dump_results=*/1, verbose);
   }
 
-  /* TODO: Luminosities check, radiation energy density check */
+  /* Run Grackle heating test with given luminosities */
+  /* ------------------------------------------------ */
+
+  if (use_const_emission_rates) {
+    for (int d = 0; d < 3; d++) {
+      float rho = dens_arr[d];
+      char fullname[80];
+      sprintf(fullname, "%s-NO_OUTPUT-LUMINOSITY_TEST", dens_names[d]);
+      run_grackle_heating_test(rho, Erad_luminosity_test_cgs, fullname, mass_units, length_units, time_units,
+                               density_units, velocity_units,
+                               internal_energy_units, /*dump_results=*/0, verbose);
+    }
+  }
 
   /* Clean up after yourself */
   free(swift_params);

--- a/GEARRTUnitCheck/src/main.c
+++ b/GEARRTUnitCheck/src/main.c
@@ -198,21 +198,23 @@ int warnings = 0;
  * @brief estimate a time step size.
  * @return time step in internal units.
  **/
-float estimate_dt(void){
-  if (smoothing_length == 0.) error("sml=0?");
-  if (c_reduced == 0.) error("c_red=0?");
+float estimate_dt(void) {
+  if (smoothing_length == 0.)
+    error("sml=0?");
+  if (c_reduced == 0.)
+    error("c_red=0?");
   return smoothing_length / c_reduced;
 }
 
-/** 
+/**
  * @brief Get an estimate for the injected radiation energy density
  * from a given luminosity.
- * 
+ *
  * @param luminosity luminosity in units of solar luminosities
  * @return the radiation energy density in internal units.
  *
  **/
-float radiation_energy_density_from_luminosity(double luminosity){
+float radiation_energy_density_from_luminosity(double luminosity) {
 
   /* To obtain some energy density, set E = L * dt / V
    * If you want to vary particle volume, you should also vary dt
@@ -220,16 +222,16 @@ float radiation_energy_density_from_luminosity(double luminosity){
    * however that the factor to modify dt and V cancels out since
    * we need dt/V, so no reason to check several scenarios there. */
 
-  const double partV = boxsize * boxsize * boxsize / (double) npart;
+  const double partV = boxsize * boxsize * boxsize / (double)npart;
   check_valid_float(partV, 0);
   const double dt = estimate_dt();
   check_valid_float(dt, 0);
-  float rad_energy_density = luminosity * const_L_Sun / power_units * dt / partV;
+  float rad_energy_density =
+      luminosity * const_L_Sun / power_units * dt / partV;
   check_valid_float(rad_energy_density, 0);
 
   return rad_energy_density;
 }
-
 
 /**
  * @brief Read in the parameters relevant for this check.
@@ -266,8 +268,8 @@ void read_swift_params(struct swift_params *params) {
     error(
         "Can't run RT with 0 photon groups. Modify RT_NGROUPS in this script.");
   } else {
-    parser_get_param_double_array(params, "GEARRT:photon_groups_Hz",
-                                  RT_NGROUPS, photon_groups_Hz);
+    parser_get_param_double_array(params, "GEARRT:photon_groups_Hz", RT_NGROUPS,
+                                  photon_groups_Hz);
   }
 
   use_const_emission_rates = parser_get_opt_param_int(
@@ -277,14 +279,15 @@ void read_swift_params(struct swift_params *params) {
     parser_get_param_double_array(params, "GEARRT:star_emission_rates_LSol",
                                   RT_NGROUPS, star_emission_rates);
   } else {
-    error("This check isn't set up to run without constant stellar emission rates (yet)");
+    error("This check isn't set up to run without constant stellar emission "
+          "rates (yet)");
   }
 }
 
 /**
  * @brief get additional internal unit conversions
  **/
-void get_internal_units(void){
+void get_internal_units(void) {
   /* Convert units */
   const double volume_units = (length_units * length_units * length_units);
   check_valid_double(volume_units, 0);
@@ -301,8 +304,11 @@ void get_internal_units(void){
    * high too. So in the end, it works out. */
   /* check_valid_float(energy_units, 0); */
   /* Nonetheless, print a warning for now. */
-  if (energy_units != 0. && (fabs(energy_units) > 1e30 || fabs(energy_units) < 1e-30)) {  
-    fprintf(stdout, "WARNING: %s:%s:%d: energy units has large exponent: %.6e\n", __FILE__, __FUNCTION__, __LINE__, energy_units); 
+  if (energy_units != 0. &&
+      (fabs(energy_units) > 1e30 || fabs(energy_units) < 1e-30)) {
+    fprintf(stdout,
+            "WARNING: %s:%s:%d: energy units has large exponent: %.6e\n",
+            __FILE__, __FUNCTION__, __LINE__, energy_units);
     warnings++;
   }
 
@@ -323,19 +329,20 @@ void read_ic_params(struct swift_params *params) {
       parser_get_param_double(params, "InternalUnitSystem:UnitMass_in_cgs");
   const double length_units_ic =
       parser_get_param_double(params, "InternalUnitSystem:UnitLength_in_cgs");
-  const double velocity_units_ic = parser_get_param_double(params,
-  "InternalUnitSystem:UnitVelocity_in_cgs");
+  const double velocity_units_ic =
+      parser_get_param_double(params, "InternalUnitSystem:UnitVelocity_in_cgs");
   /* const double temperature_units_ic = parser_get_param_double(params,
    * "InternalUnitSystem:UnitTemp_in_cgs"); */
   const double density_units_ic =
       mass_units_ic / (length_units_ic * length_units_ic * length_units_ic);
-  const double energy_units_ic = mass_units_ic * velocity_units_ic * velocity_units_ic;
+  const double energy_units_ic =
+      mass_units_ic * velocity_units_ic * velocity_units_ic;
 
   const float particle_mass_ic =
       parser_get_param_float(params, "ParticleData:ParticleMass");
   const float av_density_ic =
       parser_get_param_float(params, "ParticleData:averageDensity");
-  const float av_radiation_ic = 
+  const float av_radiation_ic =
       parser_get_param_float(params, "ParticleData:averageRadiationEnergy");
   const float boxsize_ic = parser_get_param_float(params, "GlobalData:boxsize");
   npart = parser_get_param_longlong(params, "GlobalData:npart");
@@ -347,11 +354,14 @@ void read_ic_params(struct swift_params *params) {
 
   density_average = av_density_ic * density_units_ic / density_units;
   check_valid_float(density_average, 0);
-  if (density_average > 0.) check_valid_float(density_average, 1);
+  if (density_average > 0.)
+    check_valid_float(density_average, 1);
 
   rad_energy_av = av_radiation_ic * energy_units_ic / energy_units;
-  if (rad_energy_av != 0.) check_valid_float(rad_energy_av, 0);
-  if (rad_energy_av < 0.) error("Average radiation energy = %.3g < 0", rad_energy_av);
+  if (rad_energy_av != 0.)
+    check_valid_float(rad_energy_av, 0);
+  if (rad_energy_av < 0.)
+    error("Average radiation energy = %.3g < 0", rad_energy_av);
 
   boxsize = boxsize_ic * length_units_ic / length_units;
   check_valid_float(boxsize, 1);
@@ -404,11 +414,11 @@ void read_ic_params(struct swift_params *params) {
   rad_energy_min = 0.f;
   rad_energy_max = 0.f;
   if (rad_energy_av > 0.) {
-    const double rad_energy_max_ic = 
-      parser_get_param_float(params, "ParticleData:maxRadiationEnergy");
+    const double rad_energy_max_ic =
+        parser_get_param_float(params, "ParticleData:maxRadiationEnergy");
     rad_energy_max = rad_energy_max_ic * energy_units_ic / energy_units;
-    const double rad_energy_min_ic = 
-      parser_get_param_float(params, "ParticleData:minRadiationEnergy");
+    const double rad_energy_min_ic =
+        parser_get_param_float(params, "ParticleData:minRadiationEnergy");
     rad_energy_min = rad_energy_min_ic * energy_units_ic / energy_units;
   }
 }
@@ -437,8 +447,10 @@ void print_params() {
   message("%22s: %.6e", "boxsize", boxsize);
   message("%22s: %.6e", "smoothing length", smoothing_length);
   message("%22s: %.6e", "approx dt [internal units]", estimate_dt());
-  message("%22s: %.6e", "approx dt [s]             ", estimate_dt() / time_units);
-  message("%22s: %.6e", "approx dt [kyr]           ", estimate_dt() * time_units / const_yr * 1e-3);
+  message("%22s: %.6e", "approx dt [s]             ",
+          estimate_dt() / time_units);
+  message("%22s: %.6e", "approx dt [kyr]           ",
+          estimate_dt() * time_units / const_yr * 1e-3);
 }
 
 /**
@@ -535,7 +547,8 @@ void check_gas_quantities(float density, char *name, float T, int verbose) {
  * @param T temperature to deal with
  * @param verbose are we talkative?
  **/
-void check_grackle_internals(float density, float radiation_energy_density, char *name, float T, int verbose) {
+void check_grackle_internals(float density, float radiation_energy_density,
+                             char *name, float T, int verbose) {
 
   message("checking %s, T=%.1e", name, T);
 
@@ -610,7 +623,7 @@ void check_grackle_internals(float density, float radiation_energy_density, char
 
     const double cse = 1.096971e-18;
     const double csn = 1.630511e-18;
-    const double mean_photon_energy = 4.744e-11;   /* erg */
+    const double mean_photon_energy = 4.744e-11; /* erg */
     const double E_ion = 2.179e-11; /* erg, ionization energy of hydrogen */
 
     const double Eic = radiation_energy_density * const_speed_light_c;
@@ -665,7 +678,6 @@ void check_grackle_internals(float density, float radiation_energy_density, char
   check_doubles_equal(heating_rates[1], heating_rates[2]);
 }
 
-
 /**
  * @brief Check whether other gas quantities derived from the
  * initial conditions are within an acceptable range
@@ -677,10 +689,13 @@ void check_grackle_internals(float density, float radiation_energy_density, char
  * @param T temperature to deal with
  * @param verbose are we talkative?
  **/
-void check_radiation_energies(float radEnergy, char *radName, float density, char *name, float T, int verbose) {
+void check_radiation_energies(float radEnergy, char *radName, float density,
+                              char *name, float T, int verbose) {
 
-  const double mean_particle_volume = boxsize * boxsize * boxsize / (double) npart;
-  double volumes[3] = {mean_particle_volume, 1.e-3 * mean_particle_volume, 1.e3 * mean_particle_volume};
+  const double mean_particle_volume =
+      boxsize * boxsize * boxsize / (double)npart;
+  double volumes[3] = {mean_particle_volume, 1.e-3 * mean_particle_volume,
+                       1.e3 * mean_particle_volume};
   char *vnames[3] = {"V_av", "V_min", "V_max"};
 
   char fullname[80] = "E_rad:";
@@ -700,7 +715,6 @@ void check_radiation_energies(float radEnergy, char *radName, float density, cha
     strcat(fullname, ", ");
     strcat(fullname, vnames[v]);
 
-
     const double partV = volumes[v];
     const double rad_energy_density = radEnergy / partV;
     check_valid_float(rad_energy_density, 0);
@@ -718,7 +732,8 @@ void check_radiation_energies(float radEnergy, char *radName, float density, cha
  * @param T temperature to deal with
  * @param verbose are we talkative?
  **/
-void check_luminosities(float luminosity, float density, char *name, float T, int verbose) {
+void check_luminosities(float luminosity, float density, char *name, float T,
+                        int verbose) {
 
   char fullname[80];
   sprintf(fullname, "luminosities: L=%.3g, %s", luminosity, name);
@@ -728,7 +743,8 @@ void check_luminosities(float luminosity, float density, char *name, float T, in
     return;
   }
 
-  float rad_energy_density = radiation_energy_density_from_luminosity(luminosity);
+  float rad_energy_density =
+      radiation_energy_density_from_luminosity(luminosity);
   check_grackle_internals(density, rad_energy_density, fullname, T, verbose);
 }
 
@@ -843,7 +859,7 @@ int main(void) {
     for (int t = 0; t < 7; t++) {
       float T = T_test[t];
 
-      for (int e = 0; e < 3; e++){
+      for (int e = 0; e < 3; e++) {
         float radEnergy = rad_arr[e];
         char *radName = rad_names[e];
         if (rad_energy_av > 0.)
@@ -854,10 +870,8 @@ int main(void) {
         float l = star_emission_rates[g];
         check_luminosities(l, rho, name, T, verbose);
       }
-
     }
   }
-
 
   /* Run Grackle cooling test */
   /* ------------------------ */
@@ -885,20 +899,23 @@ int main(void) {
     check_valid_double(Erad_heating_test_cgs[g], 0);
   }
 
-  double Erad_luminosity_test_cgs[RT_NGROUPS]; 
+  double Erad_luminosity_test_cgs[RT_NGROUPS];
   for (int g = 0; g < RT_NGROUPS; g++) {
-    Erad_luminosity_test_cgs[g] = radiation_energy_density_from_luminosity(star_emission_rates[g]);
+    Erad_luminosity_test_cgs[g] =
+        radiation_energy_density_from_luminosity(star_emission_rates[g]);
     Erad_luminosity_test_cgs[g] *= energy_density_units;
     check_valid_double(Erad_luminosity_test_cgs[g], 0);
   }
-
 
   /* Run Grackle heating test */
   /* ------------------------ */
   for (int d = 0; d < 3; d++) {
     float rho = dens_arr[d];
     char *name = dens_names[d];
-    run_grackle_heating_test(rho, Erad_heating_test_cgs, name, mass_units, length_units, time_units, density_units, velocity_units, internal_energy_units, /*dump_results=*/1, verbose);
+    run_grackle_heating_test(rho, Erad_heating_test_cgs, name, mass_units,
+                             length_units, time_units, density_units,
+                             velocity_units, internal_energy_units,
+                             /*dump_results=*/1, verbose);
   }
 
   /* Run Grackle heating test with given luminosities */
@@ -909,9 +926,10 @@ int main(void) {
       float rho = dens_arr[d];
       char fullname[80];
       sprintf(fullname, "%s-NO_OUTPUT-LUMINOSITY_TEST", dens_names[d]);
-      run_grackle_heating_test(rho, Erad_luminosity_test_cgs, fullname, mass_units, length_units, time_units,
-                               density_units, velocity_units,
-                               internal_energy_units, /*dump_results=*/0, verbose);
+      run_grackle_heating_test(
+          rho, Erad_luminosity_test_cgs, fullname, mass_units, length_units,
+          time_units, density_units, velocity_units, internal_energy_units,
+          /*dump_results=*/0, verbose);
     }
   }
 

--- a/grackle/include/constants.h
+++ b/grackle/include/constants.h
@@ -20,6 +20,8 @@
 #define const_speed_light_c 2.99792458e+10
 /* year in s */
 #define const_yr 31557600.
+/* Solar luminosity in erg/s */
+#define const_L_Sun 3.826e33
 #define const_adiabatic_index 1.666667
 
 #ifndef M_PI


### PR DESCRIPTION
- Added tests for suitable units for radiation densities and stellar emission rates.
- Changed to default being 3 photon groups, and ignoring frequencies 0 to first ionizing frequency.